### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/leoxlii/juice-shop-ada-1466/security/code-scanning/54](https://github.com/leoxlii/juice-shop-ada-1466/security/code-scanning/54)

To fix the problem, we should *never* pass unsanitized, user-controlled data directly into code-executed contexts such as MongoDB's `$where`, which evaluates JavaScript. The correct way is to use standard query operators (`find` with a filter object) instead of `$where`. Specifically, instead of constructing and injecting JavaScript, we should use `{ orderId: id }` as the filter, which safely matches documents with the given `orderId`.

Therefore, in `routes/trackOrder.ts`, line 18 should be replaced to use a standard query:
```ts
db.ordersCollection.find({ orderId: id })
```
This ensures that the user input is never evaluated as code, but is only matched as a value.

No additional imports or helper functions are necessary or appropriate. Some surrounding logic may be affected if the code specifically wants to demonstrate XSS or similar flaws, but for correct, safe operation, the filter replacement is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
