### PR TITLE
Potential fix for code scanning alert no. 53: Code injection

### DIFF
--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -33,7 +33,7 @@ export function showProductReviews () {
     // Measure how long the query takes, to check if there was a nosql dos attack
     const t0 = new Date().getTime()
 
-    db.reviewsCollection.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    db.reviewsCollection.find({ product: id }).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)


### PR DESCRIPTION
Potential fix for [https://github.com/leoxlii/juice-shop-ada-1466/security/code-scanning/53](https://github.com/leoxlii/juice-shop-ada-1466/security/code-scanning/53)

The secure way to query in MongoDB is never to use the `$where` operator with user input unless absolutely necessary, and certainly not with unsanitized input. In most use-cases—including this one—we do not need `$where` at all: a simple query of `{ product: id }` is correct and safe, as it will perform an exact or type-coerced match. 

Therefore, the best fix is to replace the use of `$where` with a safe direct query on the `product` field. When the challenge is not enabled, the ID is a `Number`, and when it is, it's a truncated string—either way, the query can match directly. If the actual challenge requires direct `$where` exposure for intentional exploitation, then code injection is part of the intentional gameplay, but **from a general security standpoint as required here, the fix is to entirely avoid `$where` and query using the field directly**.

- In `routes/showProductReviews.ts`, change line 36 from:
  ```ts
  db.reviewsCollection.find({ $where: 'this.product == ' + id })
  ```
  to
  ```ts
  db.reviewsCollection.find({ product: id })
  ```
- No imports or helper definitions are required, as this uses standard MongoDB query syntax.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
